### PR TITLE
Add Elapsed runtime to local jobs

### DIFF
--- a/src/cromwell_resource_crawler/jobs.py
+++ b/src/cromwell_resource_crawler/jobs.py
@@ -225,7 +225,7 @@ class SlurmJob(Job):
         except SlurmError:
             # Don't crash if one of the jobs cannot be found.
             # Return basic properties instead.
-            return props
+            pass
         if human_readable:
             for key in self._size_props:
                 size = props[key]

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -18,11 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
 import datetime
+import os
 import tempfile
 import time
-
 from pathlib import Path
 
 from cromwell_resource_crawler.jobs import LocalJob, SlurmJob
@@ -111,8 +110,8 @@ def test_local_runtime():
         jobfolder = LocalJob(Path(job))
 
         props = jobfolder.get_properties(False)
-        # If we slept for 1.5 seconds, time should at least be 1, independent of
-        # what the OS has been doing in the mean time
+        # If we slept for 1.5 seconds, time should at least be 1, independent
+        # of what the OS has been doing in the mean time
         assert props["Elapsed"] >= 1
 
         # Get the runtime in human readable format
@@ -120,6 +119,6 @@ def test_local_runtime():
         human_time = time.strptime(props["Elapsed"], '%H:%M:%S')
         # Convert it back to seconds
         seconds = datetime.timedelta(hours=human_time.tm_hour,
-                minutes=human_time.tm_min,
-                seconds=human_time.tm_sec).total_seconds()
+                                     minutes=human_time.tm_min,
+                                     seconds=human_time.tm_sec).total_seconds()
         assert seconds >= 1

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -18,6 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
+import datetime
+import tempfile
+import time
+
+from pathlib import Path
+
 from cromwell_resource_crawler.jobs import LocalJob, SlurmJob
 
 import pytest
@@ -79,3 +86,40 @@ def test_properties_raw(slurmjob):
     props = slurmjob.get_properties(False)
     assert props["CPUTime"] == 2
     assert props["MaxRSS"] == 1372160
+
+
+def test_local_runtime():
+    # Create a temporary folder for the mock execution structure
+    with tempfile.TemporaryDirectory(prefix="call-") as job:
+        # Create the execution folder
+        execution = os.path.join(job, "execution")
+        os.mkdir(execution)
+
+        # Create the script.submit file
+        script_submit = os.path.join(execution, "script.submit")
+        with open(script_submit, 'w') as fin:
+            pass
+
+        # Sleep for 1.5 seconds
+        time.sleep(1.5)
+
+        # Create the rc file
+        rc = os.path.join(execution, "rc")
+        with open(rc, 'w') as fin:
+            print("0", file=fin)
+
+        jobfolder = LocalJob(Path(job))
+
+        props = jobfolder.get_properties(False)
+        # If we slept for 1.5 seconds, time should at least be 1, independent of
+        # what the OS has been doing in the mean time
+        assert props["Elapsed"] >= 1
+
+        # Get the runtime in human readable format
+        props = jobfolder.get_properties(True)
+        human_time = time.strptime(props["Elapsed"], '%H:%M:%S')
+        # Convert it back to seconds
+        seconds = datetime.timedelta(hours=human_time.tm_hour,
+                minutes=human_time.tm_min,
+                seconds=human_time.tm_sec).total_seconds()
+        assert seconds >= 1


### PR DESCRIPTION
Add Elapsed runtime to local jobs by checking the age difference between the submit.script and the rc file cromwell writes.